### PR TITLE
Update ssh.go

### DIFF
--- a/cmd/kk/pkg/core/connector/ssh.go
+++ b/cmd/kk/pkg/core/connector/ssh.go
@@ -259,9 +259,9 @@ func (c *connection) session() (*ssh.Session, error) {
 	}
 
 	if err := sess.Setenv("LANG", "en_US.UTF-8"); err != nil { // try make sure work with english language environments
-		return nil, err
+		logger.Log.Warningf("Localization warning: Failed to enforce LANG=en_US.UTF-8. (Error: %v)", err)
 	}
-
+	
 	return sess, nil
 }
 


### PR DESCRIPTION
fix(connector): gracefully handle LANG environment setup failures



<!-- Thanks for sending a pull request! Here are some tips for you:

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
-->

### What this PR does / why we need it:

setenv 操作导致在kk 3.1.8/3.1.9 在centos/rockey linux 9.x下ssh fail ，导致无法正常部署； 经过验证不设置语言对在centos/rockey linux 9.x部署没有影响，建议setenv改为尽力而为方式更合适，失败情况下产生Warn即可。

### Which issue(s) this PR fixes:

Fixes #2546
(https://github.com/kubesphere/kubekey/issues/2546)

问题引入的pull 影响3.1.7后面的所有版本
https://github.com/kubesphere/kubekey/pull/2489
 